### PR TITLE
Fix dependencies and `conda-forge.yml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @anthchirp @h-vetinari @ndmaxar @oblute @setu4993
+* @anthchirp @h-vetinari @ndmaxar @oblute @setu4993 @xhochy

--- a/README.md
+++ b/README.md
@@ -330,4 +330,5 @@ Feedstock Maintainers
 * [@ndmaxar](https://github.com/ndmaxar/)
 * [@oblute](https://github.com/oblute/)
 * [@setu4993](https://github.com/setu4993/)
+* [@xhochy](https://github.com/xhochy/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,4 @@
 build_platform:
-  linux_aarch64: linux_64
-  linux_ppc64le: linux_64
   osx_arm64: osx_64
   linux_ppc64le: linux_64
   linux_aarch64: linux_64
@@ -8,7 +6,4 @@ conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-provider:
-  linux_aarch64: default
-  linux_ppc64le: default
-test_on_native_only: true
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-don-t-fork-on-windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib64/libgcc_s.so.1  # [linux]
@@ -33,18 +33,17 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - openssl                                # [build_platform != target_platform]
+    - maturin >=1.0,<2.0                     # [build_platform != target_platform]
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
-    - maturin
   host:
     - python
     - pip
-    - setuptools-rust >=0.11.5
-    - setuptools
-    - maturin
+    - maturin >=1.0,<2.0
     - openssl    # [linux]
   run:
     - python
+    - huggingface_hub >=0.16.4,<0.18
 
 test:
   imports:
@@ -60,7 +59,6 @@ test:
     - pip
     - pytest
     - datasets
-    - huggingface_hub < 0.17
     - numpy *
     - requests
     - curl *
@@ -96,3 +94,4 @@ extra:
     - oblute
     - setu4993
     - h-vetinari
+    - xhochy


### PR DESCRIPTION
This fixes the missing dependency of `huggingface-hub` due to which downstream `pip` check fail:  https://github.com/conda-forge/chromadb-feedstock/pull/30 Once merged, I would follow-up with a repodata patch.

Additionally, it removes duplicate keys in the `conda-forge.yml` that block the bot from making new PRs to this feedstock.